### PR TITLE
Add configuration options `terminateTimeout` and `terminateGracePeriod`

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,9 @@ title: "11. Changelog"
 
 All notable changes to this project will be documented in this section.
 
+## [1.0.0-rc.3] - Unreleased
+- feature(configuration): Add options `terminateTimeout` (default 30) and `terminateGracePeriod` (default 0) to both process and global scopes
+
 ## [1.0.0-rc.2] - 2023-07-06
 
 - chore(deps): Update dependencies

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,7 @@ title: "11. Changelog"
 All notable changes to this project will be documented in this section.
 
 ## [1.0.0-rc.3] - Unreleased
+
 - feature(configuration): Add options `terminateTimeout` (default 30) and `terminateGracePeriod` (default 0) to both process and global scopes
 
 ## [1.0.0-rc.2] - 2023-07-06

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -65,8 +65,7 @@ You need to specify one of these for each process, else the process will never s
 ### Stop/restart policy
 
 - `terminate` (optional): A cron expression specifying when the process should terminate. Combined with `restart: "always"` this effectively restarts the process on a cron schedule.
-- `terminateGracePeriod` (optional): A number specifying how many seconds to wait for a process to finish by itself before actually
-  asking it to terminate.
+- `terminateGracePeriod` (optional): A number specifying how many seconds to wait for a process to finish by itself before actually asking it to terminate.
 - `terminateTimeout` (optional): A number specifying how many seconds to wait for a process to terminate before killing it.
 
 ### Clustering

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -65,6 +65,9 @@ You need to specify one of these for each process, else the process will never s
 ### Stop/restart policy
 
 - `terminate` (optional): A cron expression specifying when the process should terminate. Combined with `restart: "always"` this effectively restarts the process on a cron schedule.
+- `terminateGracePeriod` (optional): A number specifying how many seconds to wait for a process to finish by itself before actually
+  asking it to terminate.
+- `terminateTimeout` (optional): A number specifying how many seconds to wait for a process to terminate before killing it.
 
 ### Clustering
 

--- a/docs/pup.schema.json
+++ b/docs/pup.schema.json
@@ -181,6 +181,16 @@
                 "minLength": 9,
                 "maxLength": 256
               },
+              "terminateTimeout": {
+                "type": "number",
+                "minimum": 0,
+                "default": 30
+              },
+              "terminateGracePeriod": {
+                "type": "number",
+                "minimum": 0,
+                "default": 0
+              },
               "restart": {
                 "type": "string",
                 "enum": [

--- a/docs/pup.schema.json
+++ b/docs/pup.schema.json
@@ -7,6 +7,16 @@
         "$schema": {
           "type": "string"
         },
+        "terminateTimeout": {
+          "type": "number",
+          "minimum": 0,
+          "default": 30
+        },
+        "terminateGracePeriod": {
+          "type": "number",
+          "minimum": 0,
+          "default": 0
+        },
         "logger": {
           "type": "object",
           "properties": {

--- a/lib/core/cluster.ts
+++ b/lib/core/cluster.ts
@@ -111,9 +111,9 @@ class Cluster extends Process {
     }
   }
 
-  public override stop = (reason: string): boolean => {
+  public override stop = (reason: string): Promise<boolean> => {
     const results = this.processes.map((process) => process.stop(reason))
-    return results.every((result) => result)
+    return Promise.allSettled(results).then((results) => results.every((result) => result))
   }
 
   public override restart = (reason: string) => {

--- a/lib/core/configuration.ts
+++ b/lib/core/configuration.ts
@@ -70,6 +70,8 @@ interface ProcessConfiguration {
   autostart?: boolean
   cron?: string
   terminate?: string
+  terminateTimeout?: number
+  terminateGracePeriod?: number
   timeout?: number
   overrun?: boolean
   logger?: ProcessLoggerConfiguration
@@ -126,6 +128,8 @@ const ConfigurationSchema = z.object({
       watch: z.optional(z.array(z.string())),
       cron: z.optional(z.string().min(9).max(256)),
       terminate: z.optional(z.string().min(9).max(256)),
+      terminateTimeout: z.number().min(0).default(30),
+      terminateGracePeriod: z.number().min(0).default(0),
       restart: z.optional(z.enum(["always", "error"])),
       restartDelayMs: z.number().min(0).max(24 * 60 * 60 * 1000 * 1).default(10000), // Max one day
       overrun: z.optional(z.boolean()),

--- a/lib/core/configuration.ts
+++ b/lib/core/configuration.ts
@@ -18,6 +18,8 @@ interface Configuration {
   watcher?: GlobalWatcherConfiguration
   processes: ProcessConfiguration[]
   plugins?: PluginConfiguration[]
+  terminateTimeout?: number
+  terminateGracePeriod?: number
 }
 
 interface PluginConfiguration {
@@ -82,6 +84,8 @@ interface ProcessConfiguration {
 
 const ConfigurationSchema = z.object({
   $schema: z.optional(z.string()),
+  terminateTimeout: z.number().min(0).default(30),
+  terminateGracePeriod: z.number().min(0).default(0),
   logger: z.optional(
     z.object({
       console: z.optional(z.boolean()),

--- a/lib/core/process.ts
+++ b/lib/core/process.ts
@@ -286,11 +286,13 @@ class Process {
     }).catch(() => false)
 
     const finished = new Promise<boolean>((resolve) => {
-      const onFinish = (ev) => {
-        if (ev.status.pid == this.getStatus().pid && [ProcessState.FINISHED, ProcessState.EXHAUSTED].includes(this.status)) {
+      // Using `any` because event payload is not typed yet
+      // deno-lint-ignore no-explicit-any
+      const onFinish = (ev: any) => {
+        if (ev.status?.pid == this.getStatus().pid && [ProcessState.FINISHED, ProcessState.EXHAUSTED].includes(this.status)) {
           abortTimers.abort()
           this.pup.events.off("process_status_changed", onFinish)
-          // ToDo, should resolve to whatever `killRunner()` returns, which is currently unavailable inside the `process_status_changed` event, so it's fixed to `true` by now
+          // ToDo, resolve to whatever `killRunner()` returns, which is currently unavailable inside the `process_status_changed` event, so it's fixed to `true` by now
           resolve(true)
         }
       }

--- a/lib/core/process.ts
+++ b/lib/core/process.ts
@@ -273,14 +273,14 @@ class Process {
     const abortTimers = new AbortController();
 
     // Stop process after `terminateGracePeriod`
-    delay((this.config.terminateGracePeriod ?? 0) * 1000, {signal: abortTimers.signal}).then(() => {
+    delay((this.config.terminateGracePeriod ?? this.pup.configuration.terminateGracePeriod ?? 0) * 1000, {signal: abortTimers.signal}).then(() => {
       this.pup.logger.log("stopping", `Stopping process, reason: ${reason}`, this.config)
       // ToDo, send SIGTERM or SIGINT instead of SIGKILL as soon as Dax supports it
       return this.killRunner(reason)
     }).catch(() => false),
 
     // Kill process after `terminateTimeout`
-    delay((this.config.terminateTimeout ?? 30) * 1000, {signal: abortTimers.signal}).then(() => {
+    delay((this.config.terminateTimeout ?? this.pup.configuration.terminateTimeout ?? 30) * 1000, {signal: abortTimers.signal}).then(() => {
       this.pup.logger.log("stopping", `Killing process, reason: ${reason}`, this.config)
       return this.killRunner(reason)
     }).catch(() => false)
@@ -290,6 +290,7 @@ class Process {
         if (ev.status.pid == this.getStatus().pid && [ProcessState.FINISHED, ProcessState.EXHAUSTED].includes(this.status)) {
           abortTimers.abort()
           this.pup.events.off('process_status_changed', onFinish)
+          // ToDo, should resolve to whatever `killRunner()` returns, which is currently unavailable inside the `process_status_changed` event, so it's fixed to `true` by now
           resolve(true)
         }
       }

--- a/lib/core/process.ts
+++ b/lib/core/process.ts
@@ -266,21 +266,21 @@ class Process {
    */
   public stop = async (reason: string): Promise<boolean> => {
     if (!this.runner) {
-      return false;
+      return false
     }
 
     this.setStatus(ProcessState.STOPPING)
-    const abortTimers = new AbortController();
+    const abortTimers = new AbortController()
 
     // Stop process after `terminateGracePeriod`
-    delay((this.config.terminateGracePeriod ?? this.pup.configuration.terminateGracePeriod ?? 0) * 1000, {signal: abortTimers.signal}).then(() => {
+    delay((this.config.terminateGracePeriod ?? this.pup.configuration.terminateGracePeriod ?? 0) * 1000, { signal: abortTimers.signal }).then(() => {
       this.pup.logger.log("stopping", `Stopping process, reason: ${reason}`, this.config)
       // ToDo, send SIGTERM or SIGINT instead of SIGKILL as soon as Dax supports it
       return this.killRunner(reason)
-    }).catch(() => false),
+    }).catch(() => false)
 
     // Kill process after `terminateTimeout`
-    delay((this.config.terminateTimeout ?? this.pup.configuration.terminateTimeout ?? 30) * 1000, {signal: abortTimers.signal}).then(() => {
+    delay((this.config.terminateTimeout ?? this.pup.configuration.terminateTimeout ?? 30) * 1000, { signal: abortTimers.signal }).then(() => {
       this.pup.logger.log("stopping", `Killing process, reason: ${reason}`, this.config)
       return this.killRunner(reason)
     }).catch(() => false)
@@ -289,12 +289,12 @@ class Process {
       const onFinish = (ev) => {
         if (ev.status.pid == this.getStatus().pid && [ProcessState.FINISHED, ProcessState.EXHAUSTED].includes(this.status)) {
           abortTimers.abort()
-          this.pup.events.off('process_status_changed', onFinish)
+          this.pup.events.off("process_status_changed", onFinish)
           // ToDo, should resolve to whatever `killRunner()` returns, which is currently unavailable inside the `process_status_changed` event, so it's fixed to `true` by now
           resolve(true)
         }
       }
-      this.pup.events.on('process_status_changed', onFinish)
+      this.pup.events.on("process_status_changed", onFinish)
     })
 
     return await finished

--- a/lib/core/process.ts
+++ b/lib/core/process.ts
@@ -12,7 +12,6 @@ import { WorkerRunner } from "./worker.ts"
 import { ProcessConfiguration } from "./configuration.ts"
 import { Watcher } from "./watcher.ts"
 import { TelemetryData } from "../../telemetry.ts"
-import { resolve } from "https://deno.land/std@0.183.0/path/win32.ts"
 
 /**
  * Represents the state of a process in Pup.

--- a/lib/core/pup.ts
+++ b/lib/core/pup.ts
@@ -542,32 +542,34 @@ class Pup {
 
     this.events.emit("terminating", forceQuitMs)
 
-    const stoppingProcesses: Promise<boolean>[] = [];
+    const stoppingProcesses: Promise<boolean>[] = []
 
     // Block and stop all processes
     for (const process of this.processes) {
       process.block("terminating")
-      stoppingProcesses.push(process.stop("terminating").then((result) => {
-        process.cleanup()
-        return result
-      }))
+      stoppingProcesses.push(
+        process.stop("terminating").then((result) => {
+          process.cleanup()
+          return result
+        }),
+      )
     }
-    
+
     // Close IPC
     if (this.ipc) {
       await this.ipc.close()
     }
-    
+
     // Terminate all plugins
     for (const plugin of this.plugins) {
       await plugin.terminate()
     }
-    
+
     // Cleanup
     await this.cleanup()
-    
-    await Promise.allSettled(stoppingProcesses);
-    
+
+    await Promise.allSettled(stoppingProcesses)
+
     Deno.exit(0)
   }
 

--- a/lib/core/pup.ts
+++ b/lib/core/pup.ts
@@ -542,33 +542,33 @@ class Pup {
 
     this.events.emit("terminating", forceQuitMs)
 
+    const stoppingProcesses: Promise<boolean>[] = [];
+
     // Block and stop all processes
     for (const process of this.processes) {
       process.block("terminating")
-      process.stop("terminating")
-      process.cleanup()
+      stoppingProcesses.push(process.stop("terminating").then((result) => {
+        process.cleanup()
+        return result
+      }))
     }
-
+    
     // Close IPC
     if (this.ipc) {
       await this.ipc.close()
     }
-
+    
     // Terminate all plugins
     for (const plugin of this.plugins) {
       await plugin.terminate()
     }
-
+    
     // Cleanup
     await this.cleanup()
-
-    // Now the process should exit gracefully after som time - if not,
-    // Force quit after 30 seconds
-    const timer = setTimeout(async () => {
-      await this.logger.warn("terminate", "Terminating by force")
-      Deno.exit(0)
-    }, forceQuitMs)
-    Deno.unrefTimer(timer) // Unref force quit timer to allow the process to exit earlier
+    
+    await Promise.allSettled(stoppingProcesses);
+    
+    Deno.exit(0)
   }
 
   private registerGlobalErrorHandler() {


### PR DESCRIPTION
Supersedes #35.

As far as I could tell, promisifying `process.stop()` didn't require changes anywhere it was called before. I let everything async.