### PR TITLE
Fix message "Action failed" on CLI commands `start`, `stop`, `terminate` and others

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this section.
 ## [1.0.0-rc.7] - Unreleasted
 
 - fix(configuration): Allow any value under configuration path `plugins.options`, update json schema.
+- fix(process): Many CLI commands such as `start`, `stop` and `terminate` were returning "Action failed" even though they worked.
 
 ## [1.0.0-rc.6] - 2023-07-30
 

--- a/lib/core/pup.ts
+++ b/lib/core/pup.ts
@@ -419,7 +419,7 @@ class Pup {
     if (message.data) {
       try {
         const parsedMessage = JSON.parse(message.data)
-        const response = this.handleInstruction(message)
+        const response = await this.handleInstruction(message)
 
         // If senderUuid is set, send response back to sender
         if (parsedMessage.senderUuid && uuid.v4.validate(parsedMessage.senderUuid)) {


### PR DESCRIPTION
Hey Hex 👋. I noticed this problem started in 1.0.0-rc.5. If you do `pup run` and then `pup terminate` for example, it says "Action failed" even though it worked.