### PR TITLE
Fix non finished tests (WIP)

### DIFF
--- a/lib/core/process.ts
+++ b/lib/core/process.ts
@@ -286,7 +286,7 @@ class Process {
       } else {
         this.pup.logger.log("stopping", `Stopping process, reason: ${reason}`, this.config)
       }
-      this.killRunner(reason, "SIGTERM")
+      return this.killRunner(reason, "SIGTERM")
     }).catch(() => false)
 
     // Kill process after `terminateTimeout`
@@ -304,7 +304,7 @@ class Process {
       // Using `any` because event payload is not typed yet
       // deno-lint-ignore no-explicit-any
       const onFinish = (ev: any) => {
-        if (ev.status?.pid == this.getStatus().pid && [ProcessState.FINISHED, ProcessState.EXHAUSTED].includes(this.status)) {
+        if (ev.status?.pid == this.getStatus().pid && [ProcessState.FINISHED, ProcessState.EXHAUSTED, ProcessState.ERRORED].includes(this.status)) {
           abortTimers.abort()
           this.pup.events.off("process_status_changed", onFinish)
           // ToDo, resolve to whatever `killRunner()` returns, which is currently unavailable inside the `process_status_changed` event, so it's fixed to `true` by now

--- a/test/core/pup.test.ts
+++ b/test/core/pup.test.ts
@@ -40,7 +40,7 @@ Deno.test({
     // Stop process, assert stopped
     const stopResult = await pup.stop(TEST_PROCESS_ID, "test")
     assertEquals(stopResult, true)
-    assertEquals(testProcess?.getStatus().status, ProcessState.FINISHED)
+    assertEquals(testProcess?.getStatus().status, ProcessState.ERRORED)
 
     // Block process, assert blocked
     const blockResult = pup.block(TEST_PROCESS_ID, "test")
@@ -50,7 +50,7 @@ Deno.test({
     // Start process, assert failed
     const startResult2 = pup.start(TEST_PROCESS_ID, "test")
     assertEquals(startResult2, false)
-    assertEquals(testProcess?.getStatus().status, ProcessState.FINISHED)
+    assertEquals(testProcess?.getStatus().status, ProcessState.ERRORED)
 
     // Unblock process, assert unblocked
     const unblockResult = pup.unblock(TEST_PROCESS_ID, "test")
@@ -101,7 +101,7 @@ Deno.test({
     // Stop process, assert finished
     const stopResult = await pup.stop(TEST_PROCESS_ID, "test")
     assertEquals(stopResult, true)
-    assertEquals(testProcess?.getStatus().status, ProcessState.FINISHED)
+    assertEquals(testProcess?.getStatus().status, ProcessState.ERRORED)
 
     // Block process, assert blocked
     const blockResult = pup.block(TEST_PROCESS_ID, "test")
@@ -111,7 +111,7 @@ Deno.test({
     // Start process, assert failed
     const startResult2 = pup.start(TEST_PROCESS_ID, "test")
     assertEquals(startResult2, false)
-    assertEquals(testProcess?.getStatus().status, ProcessState.FINISHED)
+    assertEquals(testProcess?.getStatus().status, ProcessState.ERRORED)
 
     // Unblock process, assert unblocked
     const unblockResult = pup.unblock(TEST_PROCESS_ID, "test")


### PR DESCRIPTION
The problem with the (now merged) PR #40 seems to be that two of the async tests never completed. In this PR, all tests do complete.

I've noticed that the processes now change to the state `ERRORED` instead of finishing when they're forcefully terminated. Consequently, I had to adjust the tests. We need to deliberate on the expected behavior here. Should a forcefully exited process have the state of `ERRORED` or `FINISHED`?

Additionally, something appears to be preventing the process from exiting immediately after the tests conclude. As a result, there's a delay of x seconds post-completion. Am I missing an issue, or could I be overthinking this? Has there always been such a delay after tests finish?

@Leokuma

(I've added you as a collaborator of pup, so that you can commit to the https://github.com/Hexagon/pup/tree/async-fix-wip branch directly to collaborate 🥷, you can possibly also push to the main branch if you want to, but try to use separate branches and PRs, and leave the releases to me for now 😄 )