### PR TITLE
Fix log order and persisting log lines that exceed Deno's KV limit

### DIFF
--- a/docs/src/changelog.md
+++ b/docs/src/changelog.md
@@ -9,6 +9,11 @@ nav_order: 13
 
 All notable changes to this project will be documented in this section.
 
+## [1.0.0-rc.12] - Unreleased
+
+- fix(logger): Store (sliced) log lines larger than Deno's KV limit of 64KiB
+- fix(logger): Guarantee that log messages are stored in chronological order per process
+
 ## [1.0.0-rc.11] - 2023-10-22
 
 - chore(deps): Full dependency update

--- a/lib/core/configuration.ts
+++ b/lib/core/configuration.ts
@@ -12,6 +12,7 @@ export const MAINTENANCE_INTERVAL_MS = 900_000
 export const WATCHDOG_INTERVAL_MS = 1_000
 export const APPLICATION_STATE_WRITE_LIMIT_MS = 20_000
 export const LOAD_BALANCER_DEFAULT_VALIDATION_INTERVAL_S = 60
+export const KV_SIZE_LIMIT_BYTES = 65_536
 
 interface Configuration {
   logger?: GlobalLoggerConfiguration

--- a/lib/core/runner.ts
+++ b/lib/core/runner.ts
@@ -82,9 +82,9 @@ class Runner extends BaseRunner {
         const r = new StringReader(new TextDecoder().decode(chunk))
         for await (const line of readLines(r)) {
           if (category === "stderr") {
-            logger.error(category, line, this.processConfig)
+            await logger.error(category, line, this.processConfig)
           } else {
-            logger.log(category, line, this.processConfig)
+            await logger.log(category, line, this.processConfig)
           }
         }
       }

--- a/test/deps.ts
+++ b/test/deps.ts
@@ -1,2 +1,2 @@
-export { assert, assertEquals, assertNotEquals, assertRejects, assertThrows } from "https://deno.land/std@0.204.0/assert/mod.ts"
+export { assert, assertEquals, assertGreater, assertNotEquals, assertRejects, assertThrows } from "https://deno.land/std@0.204.0/assert/mod.ts"
 export { assertSpyCall, spy } from "https://deno.land/std@0.204.0/testing/mock.ts"


### PR DESCRIPTION
KV has a limit of 64KiB per value. When logging lines larger than that, Pup would error and not log into KV. This PR makes Pup split long lines and log them all by adding `1` to the timestamp of each chunk. The timestamp cannot be the same for every chunk because it's used as key. Please let me know what you think of this approach.

Also, this PR guaratees that log messages are stored in order of arrival, per process.

If everything is fine, I can update the CHANGELOG.