### PR TITLE
Fix tests on Deno >= 1.37.0

### DIFF
--- a/test/core/loadbalancer.test.ts
+++ b/test/core/loadbalancer.test.ts
@@ -38,6 +38,9 @@ class MockConn implements Deno.Conn {
   upgrade(): Promise<Deno.FsFile> {
     return Promise.resolve(new Deno.FsFile(this.rid))
   }
+  [Symbol.dispose](): void {
+    this.close()
+  }
 }
 
 Deno.test("LoadBalancer - Initialization", () => {


### PR DESCRIPTION
This PR implements `Symbol.dispose` in one of the tests so that `deno check` passes in Deno >= 1.37.0.

Tests will now fail in Deno < 1.37.0 because those versions didn't have `Symbol.dispose` yet.

Pup works fine in any version, only `deno check` doesn't pass.